### PR TITLE
Load PRG ROM data into cartridge

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -17,7 +17,15 @@ fn main() {
     f.read_to_end(&mut data).unwrap();
 
     // TODO(toby): parse the file content
-    let _cartridge = nes::cartridge::parse_rom_file(&data).unwrap();
+    let cartridge = nes::cartridge::parse_rom_file(&data).unwrap();
+    print!("PRG ROM DUMP");
+    for i in 0x0000..0x07ff {
+        if i % 20 == 0 {
+            println!();
+        }
+        print!("{:02x} ", cartridge.rom.read(i));
+    }
+    println!();
 
     println!("Cartridge loaded.");
 }

--- a/src/cartridge/ines.rs
+++ b/src/cartridge/ines.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use cartridge::mapper::Mapper;
+use cartridge::mapper::MapperType;
 use cartridge::mirroring::Mirroring;
 
 const INES_HEADER: [u8; 4] = [0x4e, 0x45, 0x53, 0x1a];
@@ -30,7 +30,7 @@ const SIZE_PRG_ROM_BANK: usize = 16 * 1024;
 
 pub struct Image {
     pub mirror: Mirroring,
-    pub mapper: Mapper,
+    pub mapper: MapperType,
     pub four_screen_mirroring: bool,
     pub rom_data: Vec<u8>,
     has_trainer: bool,
@@ -99,14 +99,14 @@ fn has_four_screen_mirroring(data: &[u8]) -> bool {
     data[IDX_CB1] & CB1_BIT_FOUR_SCREEN_MIRRORING != 0
 }
 
-fn detect_mapper(data: &[u8]) -> Result<Mapper, ParseErrorReason> {
+fn detect_mapper(data: &[u8]) -> Result<MapperType, ParseErrorReason> {
     let mapper_num = (data[IDX_CB1] & CB1_MASK_MAPPER) >> 4 | (data[IDX_CB2] & CB2_MASK_MAPPER);
     // Find all known mapper numbers at https://wiki.nesdev.com/w/index.php/Mapper
     match mapper_num {
-        MAPPER_NROM => Ok(Mapper::NROM),
-        MAPPER_NINTENDO_MMC1 => Ok(Mapper::NintendoMMC1),
-        MAPPER_CNROM_SWITCH => Ok(Mapper::CNROMSwitch),
-        MAPPER_INES_211 => Ok(Mapper::INESMapper211),
+        MAPPER_NROM => Ok(MapperType::NROM),
+        MAPPER_NINTENDO_MMC1 => Ok(MapperType::NintendoMMC1),
+        MAPPER_CNROM_SWITCH => Ok(MapperType::CNROMSwitch),
+        MAPPER_INES_211 => Ok(MapperType::INESMapper211),
         _ => Err(ParseErrorReason::UnknownMapper),
     }
 }
@@ -196,25 +196,25 @@ mod tests {
     #[test]
     pub fn test_detect_mapper_none() {
         let data = [0x4e, 0x45, 0x53, 0x1a, 0x10, 0x20, 0x00, 0x00];
-        assert_eq!(detect_mapper(&data), Ok(Mapper::NROM));
+        assert_eq!(detect_mapper(&data), Ok(MapperType::NROM));
     }
 
     #[test]
     pub fn test_detect_mapper_mmc1() {
         let data = [0x4e, 0x45, 0x53, 0x1a, 0x10, 0x20, 0x10, 0x00];
-        assert_eq!(detect_mapper(&data), Ok(Mapper::NintendoMMC1));
+        assert_eq!(detect_mapper(&data), Ok(MapperType::NintendoMMC1));
     }
 
     #[test]
     pub fn test_detect_mapper_cnrom_switch() {
         let data = [0x4e, 0x45, 0x53, 0x1a, 0x02, 0x02, 0x31, 0x00];
-        assert_eq!(detect_mapper(&data), Ok(Mapper::CNROMSwitch));
+        assert_eq!(detect_mapper(&data), Ok(MapperType::CNROMSwitch));
     }
 
     #[test]
     pub fn test_detect_mapper_ines211() {
         let data = [0x4e, 0x45, 0x53, 0x1a, 0x10, 0x20, 0x30, 0xd0];
-        assert_eq!(detect_mapper(&data), Ok(Mapper::INESMapper211));
+        assert_eq!(detect_mapper(&data), Ok(MapperType::INESMapper211));
     }
 
     #[test]
@@ -230,7 +230,7 @@ mod tests {
 
         let rom = parse_rom(&data).unwrap();
         assert_eq!(rom.mirror, Mirroring::Vertical);
-        assert_eq!(rom.mapper, Mapper::CNROMSwitch);
+        assert_eq!(rom.mapper, MapperType::CNROMSwitch);
         assert_eq!(rom.four_screen_mirroring, false);
     }
 }

--- a/src/cartridge/ines.rs
+++ b/src/cartridge/ines.rs
@@ -1,9 +1,14 @@
+use std::fmt;
+
 use cartridge::mapper::Mapper;
 use cartridge::mirroring::Mirroring;
 
 const INES_HEADER: [u8; 4] = [0x4e, 0x45, 0x53, 0x1a];
 
 const LEN_NES: usize = 4;
+const LEN_HEADER: usize = 16;
+const LEN_TRAINER: usize = 512;
+
 const IDX_NUM_PRG_ROM: usize = 4;
 const IDX_NUM_CHR_ROM: usize = 5;
 const IDX_CB1: usize = 6;
@@ -21,10 +26,20 @@ const MAPPER_NINTENDO_MMC1: u8 = 1;
 const MAPPER_CNROM_SWITCH: u8 = 3;
 const MAPPER_INES_211: u8 = 211;
 
-pub struct Rom {
+const SIZE_PRG_ROM_BANK: usize = 16 * 1024;
+
+pub struct Image {
     pub mirror: Mirroring,
     pub mapper: Mapper,
     pub four_screen_mirroring: bool,
+    pub rom_data: Vec<u8>,
+    has_trainer: bool,
+}
+
+impl fmt::Debug for Image {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Image{{ has_trainer: {} }}", self.has_trainer)
+    }
 }
 
 #[derive(PartialEq, Debug)]
@@ -47,11 +62,13 @@ pub fn check_format(data: &[u8]) -> bool {
     data[..LEN_NES] == INES_HEADER
 }
 
-pub fn parse_rom(data: &[u8]) -> Result<Rom, ParseError> {
-    Ok(Rom {
+pub fn parse_rom(data: &[u8]) -> Result<Image, ParseError> {
+    Ok(Image {
         mirror: detect_mirror_type(data),
         mapper: detect_mapper(data)?,
         four_screen_mirroring: has_four_screen_mirroring(data),
+        rom_data: extract_rom_data(data),
+        has_trainer: has_trainer(data),
     })
 }
 
@@ -92,6 +109,18 @@ fn detect_mapper(data: &[u8]) -> Result<Mapper, ParseErrorReason> {
         MAPPER_INES_211 => Ok(Mapper::INESMapper211),
         _ => Err(ParseErrorReason::UnknownMapper),
     }
+}
+
+fn extract_rom_data(data: &[u8]) -> Vec<u8> {
+    let rom_start = if has_trainer(data) {
+        LEN_HEADER + LEN_TRAINER
+    } else {
+        LEN_HEADER
+    };
+
+    let len_rom: usize = count_prg_rom_banks(data) as usize * SIZE_PRG_ROM_BANK;
+
+    data[rom_start..len_rom].to_vec()
 }
 
 #[cfg(test)]

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -1,7 +1,39 @@
-#[derive(PartialEq, Debug)]
-pub enum Mapper {
+#[derive(PartialEq, Debug, Clone)]
+pub enum MapperType {
     NROM, // No mapper
     NintendoMMC1,
     CNROMSwitch,
     INESMapper211, // https://wiki.nesdev.com/w/index.php/INES_Mapper_211
+}
+
+pub trait Mapper {
+    fn map(&self, in_addr: u16) -> u16;
+}
+
+pub fn create_mapper(t: MapperType) -> Box<Mapper> {
+    match t {
+        MapperType::NROM => Box::new(NROM{}),
+        MapperType::CNROMSwitch => Box::new(CNROMSwitch{offset: 0u16}),
+        _ => panic!("Not implemented."),
+    }
+}
+
+struct NROM {}
+
+impl Mapper for NROM {
+    fn map(&self, in_addr: u16) -> u16 {
+        in_addr
+    }
+}
+
+struct CNROMSwitch {
+    // TODO(tobys): This implementation is bunk. Do a proper one.
+    offset: u16,
+}
+
+impl Mapper for CNROMSwitch {
+    // TODO(tobys): This implementation is bunk. Do a proper one.
+    fn map(&self, in_addr: u16) -> u16 {
+        in_addr + self.offset
+    }
 }

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -1,6 +1,7 @@
 mod ines;
 mod mapper;
 mod mirroring;
+mod rom;
 
 use cartridge::mapper::Mapper;
 use cartridge::mirroring::Mirroring;
@@ -8,13 +9,17 @@ use cartridge::mirroring::Mirroring;
 pub struct Cartridge {
     pub mirroring: Mirroring,
     pub memory_mapper: Mapper,
+    pub rom: rom::Rom,
 }
 
 impl Cartridge {
-    fn try_from_ines(rom: ines::Rom) -> Result<Self, ParseError> {
+    fn try_from_ines(image: ines::Image) -> Result<Self, ParseError> {
+        println!("iNES Image: {:?}", image);
+
         Ok(Cartridge {
-            mirroring: rom.mirror,
-            memory_mapper: rom.mapper,
+            mirroring: image.mirror,
+            memory_mapper: image.mapper,
+            rom: rom::Rom::new(image.rom_data),
         })
     }
 }
@@ -60,7 +65,7 @@ fn detect_format(data: &[u8]) -> Result<Format, UnknownFormat> {
 }
 
 fn parse_ines(data: &[u8]) -> Result<Cartridge, ParseError> {
-    let rom: ines::Rom = ines::parse_rom(data)?;
+    let rom: ines::Image = ines::parse_rom(data)?;
 
     Cartridge::try_from_ines(rom)
 }

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -3,13 +3,12 @@ mod mapper;
 mod mirroring;
 mod rom;
 
-use cartridge::mapper::Mapper;
+use cartridge::rom::Rom;
 use cartridge::mirroring::Mirroring;
 
 pub struct Cartridge {
     pub mirroring: Mirroring,
-    pub memory_mapper: Mapper,
-    pub rom: rom::Rom,
+    pub rom: Rom,
 }
 
 impl Cartridge {
@@ -18,8 +17,7 @@ impl Cartridge {
 
         Ok(Cartridge {
             mirroring: image.mirror,
-            memory_mapper: image.mapper,
-            rom: rom::Rom::new(image.rom_data),
+            rom: rom::Rom::new(image.rom_data, image.mapper),
         })
     }
 }

--- a/src/cartridge/rom.rs
+++ b/src/cartridge/rom.rs
@@ -1,0 +1,15 @@
+pub struct Rom {
+    content: Vec<u8>,
+}
+
+impl Rom {
+    pub fn new(content: Vec<u8>) -> Self {
+        Rom {
+            content: content,
+        }
+    }
+
+    pub fn read(&self, addr: u16) -> u8 {
+        *self.content.get(addr as usize).unwrap()
+    }
+}

--- a/src/cartridge/rom.rs
+++ b/src/cartridge/rom.rs
@@ -1,15 +1,23 @@
+use cartridge::mapper;
+use cartridge::mapper::MapperType;
+
 pub struct Rom {
     content: Vec<u8>,
+    mapper: MapperType,
 }
 
 impl Rom {
-    pub fn new(content: Vec<u8>) -> Self {
+    pub fn new(content: Vec<u8>, mapper: MapperType) -> Self {
         Rom {
             content: content,
+            mapper: mapper,
         }
     }
 
     pub fn read(&self, addr: u16) -> u8 {
-        *self.content.get(addr as usize).unwrap()
+        let mapper = mapper::create_mapper(self.mapper.clone());
+        let mapped_addr = mapper.map(addr) as usize;
+
+        *self.content.get(mapped_addr).unwrap()
     }
 }


### PR DESCRIPTION
This PR loads the PRG ROM data into the cartridge. However, it does not properly implement mappers so the read function will not be accurate just yet.