### PR TITLE
Add missing attribute preventing build

### DIFF
--- a/derives/src/lib.rs
+++ b/derives/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(proc_macro_diagnostic)]
+#![feature(proc_macro)]
 
 extern crate heck;
 extern crate proc_macro;


### PR DESCRIPTION
@joshleeb PTAL - this missing attribute was preventing running with:

`bin/run.sh ./my_game.nes`

```
error[E0658]: use of unstable library feature 'proc_macro' (see issue #38356)
  --> derives/src/lib.rs:11:18
   |
11 | use proc_macro::{Diagnostic, TokenStream};
   |                  ^^^^^^^^^^
   |
   = help: add #![feature(proc_macro)] to the crate attributes to enable
```