### PR TITLE
Remove SDL from io/video.rs

### DIFF
--- a/nes/src/bin/sdl_video_demo.rs
+++ b/nes/src/bin/sdl_video_demo.rs
@@ -1,10 +1,13 @@
 extern crate nes;
 extern crate sdl2;
 
-use nes::io::video::{SdlVideoOutput, VideoOutput};
+use nes::io::video::{ChannelVideoOutput, VideoOutput};
 use nes::ppu::palette::Color;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
+use sdl2::pixels::PixelFormatEnum;
+use sdl2::rect::Rect;
+use std::thread;
 
 fn main() {
   let sdl_context = sdl2::init().unwrap();
@@ -19,13 +22,32 @@ fn main() {
     .build()
     .unwrap();
 
-  let canvas = window.into_canvas().build().unwrap();
+  let mut canvas = window.into_canvas().build().unwrap();
   let texture_creator = canvas.texture_creator();
+  let mut texture = texture_creator
+    .create_texture_streaming(PixelFormatEnum::RGB24, 256, 240)
+    .unwrap();
 
-  let mut video_output = SdlVideoOutput::new(canvas, &texture_creator);
+  let (mut video_output, receiver) = ChannelVideoOutput::new();
 
-  let mut blue: u8 = 0;
+  // TODO: Start the PPU in this thread
+  thread::spawn(move || {
+    let mut blue: u8 = 0;
+    loop {
+      // Draw pixels one by one...
+      blue = (blue + 1) % 255;
+      for y in 0..240 {
+        for x in 0..255 {
+          video_output.output_pixel(Color(x, y, blue));
+        }
+        video_output.horizontal_sync();
+      }
+      video_output.vertical_sync();
+    }
+  });
+
   'running: loop {
+    // Handle SDL events
     for event in event_pump.poll_iter() {
       match event {
         Event::Quit { .. }
@@ -37,14 +59,27 @@ fn main() {
       }
     }
 
-    // Draw pixels one by one...
-    blue = (blue + 1) % 255;
-    for y in 0..240 {
-      for x in 0..255 {
-        video_output.output_pixel(Color(x, y, blue));
-      }
-      video_output.horizontal_sync();
-    }
-    video_output.vertical_sync();
+    // Block until a video frame is received
+    let frame = match receiver.recv() {
+      Err(_) => break,
+      Ok(f) => f,
+    };
+
+    // Write frame data to texture data
+    texture
+      .with_lock(None, |buffer: &mut [u8], pitch: usize| {
+        frame.write_to_buffer(buffer, pitch);
+      }).unwrap();
+
+    // Draw the texture to the window
+    let (width, height) = canvas.output_size().unwrap();
+    canvas.clear();
+    canvas
+      .copy(
+        &texture,
+        Some(Rect::new(0, 0, 255, 240)),
+        Some(Rect::new(0, 0, width, height)),
+      ).unwrap();
+    canvas.present();
   }
 }

--- a/nes/src/io/video.rs
+++ b/nes/src/io/video.rs
@@ -1,7 +1,5 @@
 use ppu::palette::Color;
-use sdl2;
-use sdl2::pixels::PixelFormatEnum;
-use sdl2::rect::Rect;
+use std::sync::mpsc;
 
 /// A video output simulates a composite video output,
 /// outputting one pixel at a time as well as extra
@@ -18,40 +16,56 @@ pub trait VideoOutput {
   fn vertical_sync(&mut self);
 }
 
-pub struct SdlVideoOutput<'a> {
-  canvas: sdl2::render::Canvas<sdl2::video::Window>,
-  texture: sdl2::render::Texture<'a>,
-  frame_data: Vec<Color>,
-  col: usize,
-  line: usize,
+pub struct VideoFrame {
+  /// 2D Vec of pixel values where the first dimension is the line
+  pub frame_data: Vec<Vec<Color>>,
 }
 
-impl<'a> SdlVideoOutput<'a> {
-  pub fn new(
-    canvas: sdl2::render::Canvas<sdl2::video::Window>,
-    texture_creator: &'a sdl2::render::TextureCreator<sdl2::video::WindowContext>,
-  ) -> Self {
-    let texture = texture_creator
-      .create_texture_streaming(PixelFormatEnum::RGB24, 256, 240)
-      .unwrap();
-
-    SdlVideoOutput {
-      col: 0,
-      line: 0,
-      texture: texture,
-      canvas: canvas,
-      frame_data: vec![Color(0, 0, 0); 256 * 240],
+impl VideoFrame {
+  /// Write a video frame to a flat array of RGB values (eg,
+  /// to raw texture data)
+  pub fn write_to_buffer(&self, buf: &mut [u8], pitch: usize) {
+    for (y, line) in self.frame_data.iter().enumerate() {
+      for (x, color) in line.iter().enumerate() {
+        let offset: usize = (y * pitch) + x * 3;
+        buf[offset] = color.0;
+        buf[offset + 1] = color.1;
+        buf[offset + 2] = color.2;
+      }
     }
   }
 }
 
-impl<'a> VideoOutput for SdlVideoOutput<'a> {
+/// A VideoOutput that sends frames over a synchronous channel
+pub struct ChannelVideoOutput {
+  sender: mpsc::SyncSender<VideoFrame>,
+  frame_data: Vec<Vec<Color>>,
+  col: usize,
+  line: usize,
+}
+
+impl ChannelVideoOutput {
+  pub fn new() -> (Self, mpsc::Receiver<VideoFrame>) {
+    let (send, recv) = mpsc::sync_channel(2);
+    (
+      ChannelVideoOutput {
+        sender: send,
+        col: 0,
+        line: 0,
+        frame_data: vec![vec![Color(0, 0, 0); 256]; 240],
+      },
+      recv,
+    )
+  }
+}
+
+impl VideoOutput for ChannelVideoOutput {
   fn output_pixel(&mut self, c: Color) {
     if self.col >= 256 || self.line >= 240 {
       // Overscan, ignore
       return;
     }
-    self.frame_data[self.line * 256 + self.col] = c;
+    self.frame_data[self.line][self.col] = c;
 
     self.col += 1;
   }
@@ -67,31 +81,10 @@ impl<'a> VideoOutput for SdlVideoOutput<'a> {
     self.col = 0;
     self.line = 0;
 
-    let data = &(self.frame_data);
-
     self
-      .texture
-      .with_lock(None, |buffer: &mut [u8], pitch: usize| {
-        for x in 0..256 {
-          for y in 0..240 {
-            let c = &data[y * 256 + x];
-            let offset: usize = (y * pitch) + x * 3;
-            buffer[offset] = c.0;
-            buffer[offset + 1] = c.1;
-            buffer[offset + 2] = c.2;
-          }
-        }
+      .sender
+      .send(VideoFrame {
+        frame_data: self.frame_data.clone(),
       }).unwrap();
-
-    let (width, height) = self.canvas.output_size().unwrap();
-    self.canvas.clear();
-    self
-      .canvas
-      .copy(
-        &self.texture,
-        Some(Rect::new(0, 0, 255, 240)),
-        Some(Rect::new(0, 0, width, height)),
-      ).unwrap();
-    self.canvas.present();
   }
 }


### PR DESCRIPTION
The `VideoChannel` in `video.rs` no longer cares how it's rendered, instead it simply sends frames out over a channel to be rendered in a separate thread.