### PR TITLE
Fun with video effects

### DIFF
--- a/nes/src/bin/sdl_video_demo.rs
+++ b/nes/src/bin/sdl_video_demo.rs
@@ -9,6 +9,32 @@ use sdl2::pixels::PixelFormatEnum;
 use sdl2::rect::Rect;
 use std::thread;
 
+fn test_picture_shader(x: u8, y: u8) -> Color {
+  match (x, y) {
+    (x, y) if y < 180 && x < 36 => Color(255, 255, 255),
+    (x, y) if y < 180 && x < 72 => Color(255, 255, 0),
+    (x, y) if y < 180 && x < 108 => Color(0, 255, 255),
+    (x, y) if y < 180 && x < 144 => Color(0, 255, 0),
+    (x, y) if y < 180 && x < 180 => Color(255, 0, 255),
+    (x, y) if y < 180 && x < 216 => Color(255, 0, 0),
+    (x, y) if y < 180 && x < 255 => Color(0, 0, 255),
+
+    (x, y) if y < 200 && x < 36 => Color(0, 0, 255),
+    (x, y) if y < 200 && x < 72 => Color(0, 0, 0),
+    (x, y) if y < 200 && x < 108 => Color(255, 0, 255),
+    (x, y) if y < 200 && x < 144 => Color(0, 0, 0),
+    (x, y) if y < 200 && x < 180 => Color(0, 255, 255),
+    (x, y) if y < 200 && x < 216 => Color(0, 0, 0),
+    (x, y) if y < 200 && x < 255 => Color(255, 255, 255),
+
+    (x, y) if y < 220 => Color(x, x, x),
+    (x, _) => {
+      let v = (x / 20) * 20;
+      Color(v, v, v)
+    }
+  }
+}
+
 fn main() {
   let sdl_context = sdl2::init().unwrap();
   let video_subsystem = sdl_context.video().unwrap();
@@ -31,19 +57,14 @@ fn main() {
   let (mut video_output, receiver) = ChannelVideoOutput::new();
 
   // TODO: Start the PPU in this thread
-  thread::spawn(move || {
-    let mut blue: u8 = 0;
-    loop {
-      // Draw pixels one by one...
-      blue = (blue + 1) % 255;
-      for y in 0..240 {
-        for x in 0..255 {
-          video_output.output_pixel(Color(x, y, blue));
-        }
-        video_output.horizontal_sync();
+  thread::spawn(move || loop {
+    for y in 0..240 {
+      for x in 0..255 {
+        video_output.output_pixel(test_picture_shader(x, y));
       }
-      video_output.vertical_sync();
+      video_output.horizontal_sync();
     }
+    video_output.vertical_sync();
   });
 
   'running: loop {

--- a/nes/src/io/video.rs
+++ b/nes/src/io/video.rs
@@ -25,12 +25,32 @@ impl VideoFrame {
   /// Write a video frame to a flat array of RGB values (eg,
   /// to raw texture data)
   pub fn write_to_buffer(&self, buf: &mut [u8], pitch: usize) {
+    let mut prev_color;
     for (y, line) in self.frame_data.iter().enumerate() {
+      prev_color = None;
       for (x, color) in line.iter().enumerate() {
         let offset: usize = (y * pitch) + x * 3;
-        buf[offset] = color.0;
-        buf[offset + 1] = color.1;
-        buf[offset + 2] = color.2;
+        let Color(mut r, mut g, mut b) = color.clone();
+
+        // Add scanline effect
+        if y % 2 == 0 {
+          r = r / 10 * 9;
+          g = g / 10 * 9;
+          b = b / 10 * 9;
+        }
+
+        // Blur colours between pixels
+        if let Some(Color(pr, pg, pb)) = prev_color {
+          r = (r / 2) + (pr / 2) + (r & pr & 1);
+          g = (g / 2) + (pg / 2) + (g & pg & 1);
+          b = (b / 2) + (pb / 2) + (b & pb & 1);
+        }
+
+        buf[offset] = r;
+        buf[offset + 1] = g;
+        buf[offset + 2] = b;
+
+        prev_color = Some(Color(r, g, b));
       }
     }
   }


### PR DESCRIPTION
Adds a colour bar test pattern and some super basic retro video effects:
 - Colour bleed
 - Visible scanlines

Right now it's just manipulating the pixel data directly, but ideally these would be better achieved on the SDL side of things (eg for subpixel scanlines)

![screen shot 2018-08-05 at 7 02 52 pm](https://user-images.githubusercontent.com/416133/43684366-373adeae-98e2-11e8-9a1d-c83cf70ced42.png)
